### PR TITLE
Db contrib/fixed exception on concurrent connections to pipe

### DIFF
--- a/desktop/src/Plexus.Utils.Testing/TestsSuite.cs
+++ b/desktop/src/Plexus.Utils.Testing/TestsSuite.cs
@@ -42,6 +42,16 @@ namespace Plexus
 
         protected ITestOutputHelper Console { get; }
 
+#if NET452
+        static TestsSuite()
+        {
+            // For .NET 4.5 increasing min threads count to avoid starvation and slow running in the cases 
+            // when we're creating a lot of connections in the same process concurrently (which is not a very realistic scenario in real world case)
+            ThreadPool.GetMaxThreads(out var minWorkerThreads, out var minCompletionPortThreads);
+            ThreadPool.SetMinThreads(minWorkerThreads, minCompletionPortThreads);
+        }
+#endif
+
         protected TestsSuite() : this(null)
         {
         }


### PR DESCRIPTION
- Set pipe connection timeout as combined cancellation token because passing timeout together with cancellation token leads to unexpected exceptions on .NET 4.5
- Increased min thread count in thread pool for tests on .NET 4.5